### PR TITLE
Fixed issue in hamming-benchmark where sizeof userId was wrong amount.

### DIFF
--- a/hamming_benchmark.c
+++ b/hamming_benchmark.c
@@ -40,7 +40,7 @@ void int_progression(size_t mismatches) {
 void gmp_progression(const mpz_t starting_perm, const mpz_t last_perm, const unsigned char *key,
         size_t key_size, uuid_t userId) {
     unsigned char *corrupted_key;
-    unsigned char cipher[sizeof(userId) + EVP_MAX_BLOCK_LENGTH];
+    unsigned char cipher[EVP_MAX_BLOCK_LENGTH];
     int outlen;
 
     // Initialization
@@ -54,7 +54,7 @@ void gmp_progression(const mpz_t starting_perm, const mpz_t last_perm, const uns
     while(!gmp_key_iter_end(&iter)) {
         gmp_key_iter_get(&iter, corrupted_key);
         // If encryption fails for some reason, break prematurely.
-        if(!encrypt(corrupted_key, userId, sizeof(userId), cipher, &outlen)) {
+        if(!encrypt(corrupted_key, userId, sizeof(uuid_t), cipher, &outlen)) {
             break;
         }
 


### PR DESCRIPTION
Since `userId` is passed in as an argument and is defined `typedef`'d as a `unsigned char[16]`, the compiler only sees `userId` as an `unsigned char*`. When using `sizeof(userId)`, it'd only get the size of the pointer (which for a 64-bit system is only 8 bytes). Thus, the encrypt function would only encrypt half of the `userId` instead of all 16 bytes.

NOTE: This was only fixed for `hamming-validator` before. This time it's being fixed for `hamming-benchmark`.