### PR TITLE
Added a binary source for OpenSSL 1.1.1a for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,14 @@ dist: xenial
 
 addons:
   apt:
+    sources:
+      - sourceline: "ppa:ondrej/php"
     packages:
       - libomp-dev
       - libgmp-dev
+      - libssl-dev
       - uuid-dev
       - libsqlite3-dev
-
-before_script:
-  - wget https://www.openssl.org/source/openssl-1.1.0j.tar.gz
-  - tar xf openssl-1.1.0j.tar.gz
-  - cd openssl-1.1.0j
-  - CC=gcc sudo ./config
-  - sudo make > /dev/null
-  - sudo make install > /dev/null
-  - cd ..
 
 script:
   - cmake --version


### PR DESCRIPTION
Found a PPA that supported OpenSSL 1.1.1a for Xenial to be used on Travis, instead of having to build it from scratch.