### PR TITLE
Made it so that if it is not found, then return as an error.

### DIFF
--- a/hamming_validator.c
+++ b/hamming_validator.c
@@ -16,6 +16,10 @@
 #include "gmp_key_iter.h"
 #include "util.h"
 
+#define ERROR_CODE_FOUND 0
+#define ERROR_CODE_NOT_FOUND 1
+#define ERROR_CODE_FAILURE 2
+
 /// Given a starting permutation, iterate forward through every possible permutation until one that's matching
 /// last_perm is found, or until a matching cipher is found.
 /// \param starting_perm The permutation to start iterating from.
@@ -73,6 +77,9 @@ int gmp_validator(const mpz_t starting_perm, const mpz_t last_perm, const unsign
     return found;
 }
 
+/// OpenMP implementation
+/// \return Returns a 0 on successfully finding a match, a 1 when unable to find a match,
+/// and a 2 when a general error has occurred.
 int main() {
     const size_t KEY_SIZE = 32;
     const size_t MISMATCHES = 3;
@@ -93,20 +100,20 @@ int main() {
     // Memory allocation
     if((key = malloc(sizeof(*key) * KEY_SIZE)) == NULL) {
         perror("Error");
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     if((corrupted_key = malloc(sizeof(*corrupted_key) * KEY_SIZE)) == NULL) {
         perror("Error");
         free(key);
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     if((starting_perms = malloc(sizeof(*starting_perms) * starting_perms_size)) == NULL) {
         perror("Error");
         free(key);
         free(corrupted_key);
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     for(size_t i = 0; i < starting_perms_size; i++) {
@@ -139,7 +146,7 @@ int main() {
         free(corrupted_key);
         free(key);
 
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     generate_starting_permutations(starting_perms, starting_perms_size, MISMATCHES, KEY_SIZE);
@@ -187,5 +194,5 @@ int main() {
     free(corrupted_key);
     free(key);
 
-    return found ? EXIT_SUCCESS: EXIT_FAILURE;
+    return found ? ERROR_CODE_FOUND: ERROR_CODE_NOT_FOUND;
 }

--- a/hamming_validator_fork.c
+++ b/hamming_validator_fork.c
@@ -18,6 +18,10 @@
 #include "gmp_key_iter.h"
 #include "util.h"
 
+#define ERROR_CODE_FOUND 0
+#define ERROR_CODE_NOT_FOUND 1
+#define ERROR_CODE_FAILURE 2
+
 /// Given a starting permutation, iterate forward through every possible permutation until one that's matching
 /// last_perm is found, or until a matching cipher is found.
 /// \param starting_perm The permutation to start iterating from.
@@ -75,6 +79,9 @@ int gmp_validator(const mpz_t starting_perm, const mpz_t last_perm, const unsign
     return found;
 }
 
+/// Fork implementation
+/// \return Returns a 0 on successfully finding a match, a 1 when unable to find a match,
+/// and a 2 when a general error has occurred.
 int main() {
     const size_t KEY_SIZE = 32;
     const size_t MISMATCHES = 3;
@@ -96,13 +103,13 @@ int main() {
     // Memory allocation
     if((key = malloc(sizeof(*key) * KEY_SIZE)) == NULL) {
         perror("Error");
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     if((corrupted_key = malloc(sizeof(*corrupted_key) * KEY_SIZE)) == NULL) {
         perror("Error");
         free(key);
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     mpz_inits(starting_perm, ending_perm, NULL);
@@ -128,7 +135,7 @@ int main() {
         free(corrupted_key);
         free(key);
 
-        return EXIT_FAILURE;
+        return ERROR_CODE_FAILURE;
     }
 
     clock_gettime(CLOCK_MONOTONIC, &startTime);
@@ -175,5 +182,5 @@ int main() {
     free(corrupted_key);
     free(key);
 
-    return WEXITSTATUS(status) ? EXIT_SUCCESS : EXIT_FAILURE;
+    return WEXITSTATUS(status) ? ERROR_CODE_FOUND : ERROR_CODE_NOT_FOUND;
 }


### PR DESCRIPTION
Before, it would return on success regardless of the found status. In truth, if it is not found, then from the benchmark standpoint this is an "error" and should be checked against with Travis CI.

Specifically now (for `hamming_validator` and `hamming_validator_fork`):
* Returns **0** means program exited gracefully and _found a match_.
* Returns **1** means program exited gracefully and _did not find a match_.
* Returns **2** means program didn't exit gracefully (see error message).