### PR TITLE
Revert "Moved some tmp variables from seed iter to next function"

### DIFF
--- a/src/seed_iter.c
+++ b/src/seed_iter.c
@@ -47,12 +47,9 @@ int seed_iter_init(seed_iter *iter, const unsigned char *seed, size_t seed_size,
 }
 
 void seed_iter_next(seed_iter *iter) {
-    mp_limb_t t[ITER_LIMB_SIZE];
-    mp_limb_t tmp[ITER_LIMB_SIZE];
-
     // Equivalent to: t = perm | (perm - 1)
-    mpn_sub_1(t, iter->curr_perm, ITER_LIMB_SIZE, 1);
-    mpn_ior_n(t, t, iter->curr_perm, ITER_LIMB_SIZE);
+    mpn_sub_1(iter->t, iter->curr_perm, ITER_LIMB_SIZE, 1);
+    mpn_ior_n(iter->t, iter->t, iter->curr_perm, ITER_LIMB_SIZE);
 
     // Equivalent to: perm = (t + 1) | (((~t & -~t) - 1) >> (__builtin_ctz(perm) + 1))
     unsigned int shift;
@@ -62,17 +59,17 @@ void seed_iter_next(seed_iter *iter) {
     else {
         shift = mpn_scan1(iter->curr_perm, 0) + 1;
     }
-    mpn_com(iter->curr_perm, t, ITER_LIMB_SIZE);
-    mpn_neg(tmp, iter->curr_perm, ITER_LIMB_SIZE);
-    mpn_and_n(iter->curr_perm, iter->curr_perm, tmp, ITER_LIMB_SIZE);
+    mpn_com(iter->curr_perm, iter->t, ITER_LIMB_SIZE);
+    mpn_neg(iter->tmp, iter->curr_perm, ITER_LIMB_SIZE);
+    mpn_and_n(iter->curr_perm, iter->curr_perm, iter->tmp, ITER_LIMB_SIZE);
     mpn_sub_1(iter->curr_perm, iter->curr_perm, ITER_LIMB_SIZE, 1);
 
     // Right shift by the ctz + 1
     mpn_overflowing_rshift(iter->curr_perm, iter->curr_perm, ITER_LIMB_SIZE, shift);
 
     // This is the only portion that can potentially overflow
-    iter->overflow = mpn_add_1(t, t, ITER_LIMB_SIZE, 1);
-    mpn_ior_n(iter->curr_perm, iter->curr_perm, t, ITER_LIMB_SIZE);
+    iter->overflow = mpn_add_1(iter->t, iter->t, ITER_LIMB_SIZE, 1);
+    mpn_ior_n(iter->curr_perm, iter->curr_perm, iter->t, ITER_LIMB_SIZE);
 
     // Perform an XOR operation between the permutation and the key.
     // If a bit is set in permutation, then flip the bit in the key.

--- a/src/seed_iter.h
+++ b/src/seed_iter.h
@@ -15,6 +15,8 @@ typedef struct seed_iter {
     mp_limb_t overflow;
     mp_limb_t curr_perm[ITER_LIMB_SIZE];
     mp_limb_t last_perm[ITER_LIMB_SIZE];
+    mp_limb_t t[ITER_LIMB_SIZE];
+    mp_limb_t tmp[ITER_LIMB_SIZE];
     mp_limb_t seed_mpn[ITER_LIMB_SIZE];
     mp_limb_t corrupted_seed_mpn[ITER_LIMB_SIZE];
 } seed_iter;


### PR DESCRIPTION
Reverts GiantDarth/rbc_validator#97

Reverting so as to be able to cleanse efficiently only when destroyed.