### PR TITLE
Add support for XOFs and added SHAKE128 and SHAKE256

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif(UNIX AND NOT CYGWIN AND NOT APPLE)
 
 set(ALWAYS_EVP_AES OFF CACHE BOOL "Force AES to use OpenSSL's EVP system instead of a custom implementation.")
 set(ALWAYS_EVP_HASH OFF CACHE BOOL "Force MD5, SHA1, and SHA2 to use OpenSSL's EVP system instead.")
-set(ALWAYS_EVP_SHA3 ON CACHE BOOL "Force all SHA-3 algorithms to use OpenSSL's EVP over XKCP.")
+set(ALWAYS_EVP_SHA3 ON CACHE BOOL "Force all SHA-3 and SHAKE algorithms to use OpenSSL's EVP over XKCP.")
 
 set(SOURCE_FILES src/seed_iter.c src/seed_iter.h src/perm.c src/perm.h
         src/uuid.c src/uuid.h)

--- a/args_mpi.ggo
+++ b/args_mpi.ggo
@@ -5,8 +5,8 @@ purpose "\nGiven an HOST_SEED and either:
 1) an AES256 CLIENT_CIPHER and plaintext UUID;
 2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;
 3) an ECC Secp256r1 CLIENT_PUB_KEY;
-4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256, SHA3-384, SHA3-512, or \
-KangarooTwelve CLIENT_DIGEST;
+4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256, SHA3-384, SHA3-512, \
+SHAKE128, SHAKE256, or KangarooTwelve CLIENT_DIGEST;
 where CLIENT_* is from an unreliable source. \
 Progressively corrupt the chosen cryptographic function by a certain \
 number of bits until a matching client seed is found. The matching \
@@ -18,7 +18,7 @@ usage "rbc_validator_mpi [OPTIONS...] --mode=none HOST_SEED
   or : rbc_validator_mpi [OPTIONS...] --mode=[aes,chacha20] HOST_SEED CLIENT_CIPHER UUID [IV]
   or : rbc_validator_mpi [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY
   or : rbc_validator_mpi [OPTIONS...] --mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,\
-sha3-384,sha3-512,kang12] HOST_SEED CLIENT_DIGEST [SALT]
+sha3-384,sha3-512,shake128,shake256,kang12] HOST_SEED CLIENT_DIGEST [SALT]
   or : rbc_validator_mpi [OPTIONS...] --mode=* -r/--random -m/--mismatches=value
   or : rbc_validator_mpi [OPTIONS...] --mode=* -b/--benchmark -m/--mismatches=value
 Try `rbc_validator_mpi --help' for more information."
@@ -47,7 +47,7 @@ option "usage" - "Give a short usage message"
 option "mode" - "(REQUIRED) The cryptographic function to iterate against. If `none', then only perform
 seed iteration."
     enum values="none","aes","chacha20","ecc","md5","sha1","sha224","sha256","sha384","sha512",
-"sha3-224","sha3-256","sha3-384","sha3-512","kang12"
+"sha3-224","sha3-256","sha3-384","sha3-512","shake128","shake256","kang12"
 
 option "mismatches" m "The largest # of bits of corruption to test against, inclusively. \
 Defaults to -1. If negative, then the size of key in bits will be the limit. If in random or \

--- a/args_omp.ggo
+++ b/args_omp.ggo
@@ -5,8 +5,8 @@ purpose "\nGiven an HOST_SEED and either:
 1) an AES256 CLIENT_CIPHER and plaintext UUID;
 2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;
 3) an ECC Secp256r1 CLIENT_PUB_KEY;
-4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256, SHA3-384, SHA3-512, or \
-KangarooTwelve CLIENT_DIGEST;
+4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256, SHA3-384, SHA3-512, \
+SHAKE128, SHAKE256, or KangarooTwelve CLIENT_DIGEST;
 where CLIENT_* is from an unreliable source. \
 Progressively corrupt the chosen cryptographic function by a certain \
 number of bits until a matching client seed is found. The matching \
@@ -18,7 +18,7 @@ usage "rbc_validator [OPTIONS...] --mode=none HOST_SEED
   or : rbc_validator [OPTIONS...] --mode=[aes,chacha20] HOST_SEED CLIENT_CIPHER UUID [IV]
   or : rbc_validator [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY
   or : rbc_validator [OPTIONS...] --mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,\
-sha3-384,sha3-512,kang12] HOST_SEED CLIENT_DIGEST [SALT]
+sha3-384,sha3-512,shake128,shake256,kang12] HOST_SEED CLIENT_DIGEST [SALT]
   or : rbc_validator [OPTIONS...] --mode=* -r/--random -m/--mismatches=value
   or : rbc_validator [OPTIONS...] --mode=* -b/--benchmark -m/--mismatches=value
 Try `rbc_validator_mpi --help' for more information."
@@ -47,7 +47,7 @@ option "usage" - "Give a short usage message"
 option "mode" - "(REQUIRED) The cryptographic function to iterate against. If `none', then only perform
 seed iteration."
     enum values="none","aes","chacha20","ecc","md5","sha1","sha224","sha256","sha384","sha512",
-"sha3-224","sha3-256","sha3-384","sha3-512","kang12"
+"sha3-224","sha3-256","sha3-384","sha3-512","shake128","shake256","kang12"
 
 option "mismatches" m "The largest # of bits of corruption to test against, inclusively. \
 Defaults to -1. If negative, then the size of key in bits will be the limit. If in random or \

--- a/src/cmdline/cmdline_mpi.c
+++ b/src/cmdline/cmdline_mpi.c
@@ -25,9 +25,9 @@
 
 #include "cmdline_mpi.h"
 
-const char *gengetopt_args_info_purpose = "\nGiven an HOST_SEED and either:\n1) an AES256 CLIENT_CIPHER and plaintext UUID;\n2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;\n3) an ECC Secp256r1 CLIENT_PUB_KEY;\n4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256,\nSHA3-384, SHA3-512, or KangarooTwelve CLIENT_DIGEST;\nwhere CLIENT_* is from an unreliable source. Progressively corrupt the chosen\ncryptographic function by a certain number of bits until a matching client seed\nis found. The matching HOST_* will be sent to stdout, depending on the\ncryptographic function.\n\nThis implementation uses MPI.";
+const char *gengetopt_args_info_purpose = "\nGiven an HOST_SEED and either:\n1) an AES256 CLIENT_CIPHER and plaintext UUID;\n2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;\n3) an ECC Secp256r1 CLIENT_PUB_KEY;\n4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256,\nSHA3-384, SHA3-512, SHAKE128, SHAKE256, or KangarooTwelve CLIENT_DIGEST;\nwhere CLIENT_* is from an unreliable source. Progressively corrupt the chosen\ncryptographic function by a certain number of bits until a matching client seed\nis found. The matching HOST_* will be sent to stdout, depending on the\ncryptographic function.\n\nThis implementation uses MPI.";
 
-const char *gengetopt_args_info_usage = "Usage: rbc_validator_mpi [OPTIONS...] --mode=none HOST_SEED\n  or : rbc_validator_mpi [OPTIONS...] --mode=[aes,chacha20] HOST_SEED\nCLIENT_CIPHER UUID [IV]\n  or : rbc_validator_mpi [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY\n  or : rbc_validator_mpi [OPTIONS...]\n--mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,sha3-384,sha3-512,kang12]\nHOST_SEED CLIENT_DIGEST [SALT]\n  or : rbc_validator_mpi [OPTIONS...] --mode=* -r/--random\n-m/--mismatches=value\n  or : rbc_validator_mpi [OPTIONS...] --mode=* -b/--benchmark\n-m/--mismatches=value\nTry `rbc_validator_mpi --help' for more information.";
+const char *gengetopt_args_info_usage = "Usage: rbc_validator_mpi [OPTIONS...] --mode=none HOST_SEED\n  or : rbc_validator_mpi [OPTIONS...] --mode=[aes,chacha20] HOST_SEED\nCLIENT_CIPHER UUID [IV]\n  or : rbc_validator_mpi [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY\n  or : rbc_validator_mpi [OPTIONS...]\n--mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,sha3-384,sha3-512,shake128,shake256,kang12]\nHOST_SEED CLIENT_DIGEST [SALT]\n  or : rbc_validator_mpi [OPTIONS...] --mode=* -r/--random\n-m/--mismatches=value\n  or : rbc_validator_mpi [OPTIONS...] --mode=* -b/--benchmark\n-m/--mismatches=value\nTry `rbc_validator_mpi --help' for more information.";
 
 const char *gengetopt_args_info_versiontext = "Christopher Robert Philabaum <cp723@nau.edu>";
 
@@ -37,7 +37,7 @@ const char *gengetopt_args_info_help[] = {
   "  -h, --help              Print help and exit",
   "  -V, --version           Print version and exit",
   "      --usage             Give a short usage message",
-  "      --mode=ENUM         (REQUIRED) The cryptographic function to iterate\n                            against. If `none', then only perform\n                            seed iteration.  (possible values=\"none\",\n                            \"aes\", \"chacha20\", \"ecc\", \"md5\", \"sha1\",\n                            \"sha224\", \"sha256\", \"sha384\", \"sha512\",\n                            \"sha3-224\", \"sha3-256\", \"sha3-384\",\n                            \"sha3-512\", \"kang12\")",
+  "      --mode=ENUM         (REQUIRED) The cryptographic function to iterate\n                            against. If `none', then only perform\n                            seed iteration.  (possible values=\"none\",\n                            \"aes\", \"chacha20\", \"ecc\", \"md5\", \"sha1\",\n                            \"sha224\", \"sha256\", \"sha384\", \"sha512\",\n                            \"sha3-224\", \"sha3-256\", \"sha3-384\",\n                            \"sha3-512\", \"shake128\", \"shake256\",\n                            \"kang12\")",
   "  -m, --mismatches=value  The largest # of bits of corruption to test against,\n                            inclusively. Defaults to -1. If negative, then the\n                            size of key in bits will be the limit. If in random\n                            or benchmark mode, then this will also be used to\n                            corrupt the random key by the same # of bits; for\n                            this reason, it must be set and non-negative when\n                            in random or benchmark mode. Cannot be larger than\n                            what --subkey-size is set to.  (default=`-1')",
   "  -s, --subkey=value      How many of the first bits to corrupt and iterate\n                            over. Must be between 1 and 256. Defaults to 256.\n                            (default=`256')",
   "\n Mode: Random",
@@ -67,7 +67,7 @@ cmdline_parser_internal (int argc, char **argv, struct gengetopt_args_info *args
                         struct cmdline_parser_params *params, const char *additional_error);
 
 
-const char *cmdline_parser_mode_values[] = {"none", "aes", "chacha20", "ecc", "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "kang12", 0}; /*< Possible values for mode. */
+const char *cmdline_parser_mode_values[] = {"none", "aes", "chacha20", "ecc", "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake128", "shake256", "kang12", 0}; /*< Possible values for mode. */
 
 static char *
 gengetopt_strdup (const char *s);

--- a/src/cmdline/cmdline_mpi.h
+++ b/src/cmdline/cmdline_mpi.h
@@ -34,7 +34,7 @@ extern "C" {
 #define CMDLINE_PARSER_VERSION "v0.1.0"
 #endif
 
-enum enum_mode { mode__NULL = -1, mode_arg_none = 0, mode_arg_aes, mode_arg_chacha20, mode_arg_ecc, mode_arg_md5, mode_arg_sha1, mode_arg_sha224, mode_arg_sha256, mode_arg_sha384, mode_arg_sha512, mode_arg_sha3MINUS_224, mode_arg_sha3MINUS_256, mode_arg_sha3MINUS_384, mode_arg_sha3MINUS_512, mode_arg_kang12 };
+enum enum_mode { mode__NULL = -1, mode_arg_none = 0, mode_arg_aes, mode_arg_chacha20, mode_arg_ecc, mode_arg_md5, mode_arg_sha1, mode_arg_sha224, mode_arg_sha256, mode_arg_sha384, mode_arg_sha512, mode_arg_sha3MINUS_224, mode_arg_sha3MINUS_256, mode_arg_sha3MINUS_384, mode_arg_sha3MINUS_512, mode_arg_shake128, mode_arg_shake256, mode_arg_kang12 };
 
 /** @brief Where the command line options are stored */
 struct gengetopt_args_info

--- a/src/cmdline/cmdline_omp.c
+++ b/src/cmdline/cmdline_omp.c
@@ -25,9 +25,9 @@
 
 #include "cmdline_omp.h"
 
-const char *gengetopt_args_info_purpose = "\nGiven an HOST_SEED and either:\n1) an AES256 CLIENT_CIPHER and plaintext UUID;\n2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;\n3) an ECC Secp256r1 CLIENT_PUB_KEY;\n4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256,\nSHA3-384, SHA3-512, or KangarooTwelve CLIENT_DIGEST;\nwhere CLIENT_* is from an unreliable source. Progressively corrupt the chosen\ncryptographic function by a certain number of bits until a matching client seed\nis found. The matching HOST_* will be sent to stdout, depending on the\ncryptographic function.\n\nThis implementation uses OpenMP.";
+const char *gengetopt_args_info_purpose = "\nGiven an HOST_SEED and either:\n1) an AES256 CLIENT_CIPHER and plaintext UUID;\n2) a ChaCha20 CLIENT_CIPHER, plaintext UUID, and IV;\n3) an ECC Secp256r1 CLIENT_PUB_KEY;\n4) a MD5, SHA1, SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA3-224, SHA3-256,\nSHA3-384, SHA3-512, SHAKE128, SHAKE256, or KangarooTwelve CLIENT_DIGEST;\nwhere CLIENT_* is from an unreliable source. Progressively corrupt the chosen\ncryptographic function by a certain number of bits until a matching client seed\nis found. The matching HOST_* will be sent to stdout, depending on the\ncryptographic function.\n\nThis implementation uses OpenMP.";
 
-const char *gengetopt_args_info_usage = "Usage: rbc_validator [OPTIONS...] --mode=none HOST_SEED\n  or : rbc_validator [OPTIONS...] --mode=[aes,chacha20] HOST_SEED CLIENT_CIPHER\nUUID [IV]\n  or : rbc_validator [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY\n  or : rbc_validator [OPTIONS...]\n--mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,sha3-384,sha3-512,kang12]\nHOST_SEED CLIENT_DIGEST [SALT]\n  or : rbc_validator [OPTIONS...] --mode=* -r/--random -m/--mismatches=value\n  or : rbc_validator [OPTIONS...] --mode=* -b/--benchmark -m/--mismatches=value\nTry `rbc_validator_mpi --help' for more information.";
+const char *gengetopt_args_info_usage = "Usage: rbc_validator [OPTIONS...] --mode=none HOST_SEED\n  or : rbc_validator [OPTIONS...] --mode=[aes,chacha20] HOST_SEED CLIENT_CIPHER\nUUID [IV]\n  or : rbc_validator [OPTIONS...] --mode=ecc HOST_SEED CLIENT_PUB_KEY\n  or : rbc_validator [OPTIONS...]\n--mode=[md5,sha1,sha224,sha256,sha384,sha512,sha3-224,sha3-256,sha3-384,sha3-512,shake128,shake256,kang12]\nHOST_SEED CLIENT_DIGEST [SALT]\n  or : rbc_validator [OPTIONS...] --mode=* -r/--random -m/--mismatches=value\n  or : rbc_validator [OPTIONS...] --mode=* -b/--benchmark -m/--mismatches=value\nTry `rbc_validator_mpi --help' for more information.";
 
 const char *gengetopt_args_info_versiontext = "Christopher Robert Philabaum <cp723@nau.edu>";
 
@@ -37,7 +37,7 @@ const char *gengetopt_args_info_help[] = {
   "  -h, --help              Print help and exit",
   "  -V, --version           Print version and exit",
   "      --usage             Give a short usage message",
-  "      --mode=ENUM         (REQUIRED) The cryptographic function to iterate\n                            against. If `none', then only perform\n                            seed iteration.  (possible values=\"none\",\n                            \"aes\", \"chacha20\", \"ecc\", \"md5\", \"sha1\",\n                            \"sha224\", \"sha256\", \"sha384\", \"sha512\",\n                            \"sha3-224\", \"sha3-256\", \"sha3-384\",\n                            \"sha3-512\", \"kang12\")",
+  "      --mode=ENUM         (REQUIRED) The cryptographic function to iterate\n                            against. If `none', then only perform\n                            seed iteration.  (possible values=\"none\",\n                            \"aes\", \"chacha20\", \"ecc\", \"md5\", \"sha1\",\n                            \"sha224\", \"sha256\", \"sha384\", \"sha512\",\n                            \"sha3-224\", \"sha3-256\", \"sha3-384\",\n                            \"sha3-512\", \"shake128\", \"shake256\",\n                            \"kang12\")",
   "  -m, --mismatches=value  The largest # of bits of corruption to test against,\n                            inclusively. Defaults to -1. If negative, then the\n                            size of key in bits will be the limit. If in random\n                            or benchmark mode, then this will also be used to\n                            corrupt the random key by the same # of bits; for\n                            this reason, it must be set and non-negative when\n                            in random or benchmark mode. Cannot be larger than\n                            what --subkey-size is set to.  (default=`-1')",
   "  -s, --subkey=value      How many of the first bits to corrupt and iterate\n                            over. Must be between 1 and 256. Defaults to 256.\n                            (default=`256')",
   "\n Mode: Random",
@@ -68,7 +68,7 @@ cmdline_parser_internal (int argc, char **argv, struct gengetopt_args_info *args
                         struct cmdline_parser_params *params, const char *additional_error);
 
 
-const char *cmdline_parser_mode_values[] = {"none", "aes", "chacha20", "ecc", "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "kang12", 0}; /*< Possible values for mode. */
+const char *cmdline_parser_mode_values[] = {"none", "aes", "chacha20", "ecc", "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake128", "shake256", "kang12", 0}; /*< Possible values for mode. */
 
 static char *
 gengetopt_strdup (const char *s);

--- a/src/cmdline/cmdline_omp.h
+++ b/src/cmdline/cmdline_omp.h
@@ -34,7 +34,7 @@ extern "C" {
 #define CMDLINE_PARSER_VERSION "v0.1.0"
 #endif
 
-enum enum_mode { mode__NULL = -1, mode_arg_none = 0, mode_arg_aes, mode_arg_chacha20, mode_arg_ecc, mode_arg_md5, mode_arg_sha1, mode_arg_sha224, mode_arg_sha256, mode_arg_sha384, mode_arg_sha512, mode_arg_sha3MINUS_224, mode_arg_sha3MINUS_256, mode_arg_sha3MINUS_384, mode_arg_sha3MINUS_512, mode_arg_kang12 };
+enum enum_mode { mode__NULL = -1, mode_arg_none = 0, mode_arg_aes, mode_arg_chacha20, mode_arg_ecc, mode_arg_md5, mode_arg_sha1, mode_arg_sha224, mode_arg_sha256, mode_arg_sha384, mode_arg_sha512, mode_arg_sha3MINUS_224, mode_arg_sha3MINUS_256, mode_arg_sha3MINUS_384, mode_arg_sha3MINUS_512, mode_arg_shake128, mode_arg_shake256, mode_arg_kang12 };
 
 /** @brief Where the command line options are stored */
 struct gengetopt_args_info

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -7,29 +7,146 @@
 
 #include <openssl/evp.h>
 
-int evp_hash(unsigned char *digest, EVP_MD_CTX *ctx, const EVP_MD *md,
-             const unsigned char *msg, size_t msg_size,
+#define NID_kang12 -1
+
+/// A generic function that allows for any combination of hash functions through OpenSSL's EVP system.
+/// \param digest The output digest. It must be pre-allocated with at least the correct digest size.
+/// \param digest_size Either NULL for any non-XOF, or the wanted digest size when using EVP_shake128
+/// or EVP_shake256. Using a non-NULL size on a non-XOF is undefined behavior.
+/// \param ctx A context the perform the digest operations in. If NULL (aka. not pre-allocated), then
+/// it will allocate and destroy a temporary context at the cost of performance.
+/// \param md Which hash function to use.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
+int evp_hash(unsigned char *digest, const size_t *digest_size, EVP_MD_CTX *ctx,
+             const EVP_MD *md, const unsigned char *msg, size_t msg_size,
              const unsigned char *salt, size_t salt_size);
+/// Perform MD5 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 16 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int md5_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
              const unsigned char *salt, size_t salt_size);
+/// Perform SHA1 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 20 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha1_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
               const unsigned char *salt, size_t salt_size);
+/// Perform SHA224 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 24 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha224_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                 const unsigned char *salt, size_t salt_size);
+/// Perform SHA256 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 32 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha256_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                 const unsigned char *salt, size_t salt_size);
+/// Perform SHA384 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 48 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha384_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                 const unsigned char *salt, size_t salt_size);
+/// Perform SHA512 using OpenSSL's faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 64 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha512_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                 const unsigned char *salt, size_t salt_size);
+/// Perform SHA3-224 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 24 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha3_224_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                   const unsigned char *salt, size_t salt_size);
+/// Perform SHA3-256 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 32 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha3_256_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                   const unsigned char *salt, size_t salt_size);
+/// Perform SHA3-384 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 48 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha3_384_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                   const unsigned char *salt, size_t salt_size);
+/// Perform SHA3-512 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least 64 bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int sha3_512_hash(unsigned char *digest, const unsigned char *msg, size_t msg_size,
                   const unsigned char *salt, size_t salt_size);
+/// Perform SHAKE128 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least digest_size bytes.
+/// \param digest_size How many bytes you want to fill digest with. digest must be pre-allocated
+/// with at least this many bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
+int shake128_hash(unsigned char *digest, size_t digest_size,
+                  const unsigned char *msg, size_t msg_size,
+                  const unsigned char *salt, size_t salt_size);
+/// Perform SHAKE256 using XKCP's (potentially) faster low level functions.
+/// \param digest The output digest. It must be pre-allocated with at least digest_size bytes.
+/// \param digest_size How many bytes you want to fill digest with. digest must be pre-allocated
+/// with at least this many bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
+int shake256_hash(unsigned char *digest, size_t digest_size,
+                  const unsigned char *msg, size_t msg_size,
+                  const unsigned char *salt, size_t salt_size);
+/// Perform KangarooTwelve using XKCP.
+/// \param digest The output digest. It must be pre-allocated with at least digest_size bytes.
+/// \param digest_size How many bytes you want to fill digest with. digest must be pre-allocated
+/// with at least this many bytes.
+/// \param msg The message to hash, must have at least msg_size bytes allocated.
+/// \param msg_size How many bytes are allocated for msg.
+/// \param salt An additional, optional salt that will perform a secondary update after msg.
+/// \param salt_size How big the salt is. If salt is NULL, then this value is ignored.
+/// \return Returns a 0 on success and a 1 on failure.
 int kang12_hash(unsigned char *digest, size_t digest_size, const unsigned char *msg, size_t msg_size,
                 const unsigned char *salt, size_t salt_size);
 

--- a/src/hash_test.c
+++ b/src/hash_test.c
@@ -22,7 +22,7 @@ int generic_test(const char *name, const EVP_MD *md, const unsigned char *msg,
         return -1;
     }
 
-    if(evp_hash(digest, NULL, md, msg, msg_size, NULL, 0)) {
+    if(evp_hash(digest, NULL, NULL, md, msg, msg_size, NULL, 0)) {
         fprintf(stderr, "ERROR: evp_hash failed\n");
         free(digest);
 

--- a/src/validator.h
+++ b/src/validator.h
@@ -29,6 +29,7 @@ typedef struct ec_validator_t {
 
 typedef struct hash_validator_t {
     const EVP_MD *md;
+    int is_xof;
     int nid;
     size_t digest_size, salt_size;
     EVP_MD_CTX *ctx;
@@ -62,7 +63,7 @@ ec_validator_t *ec_validator_create(const EC_GROUP *group, const EC_POINT *clien
 void ec_validator_destroy(ec_validator_t *v);
 
 hash_validator_t *hash_validator_create(const EVP_MD *md, const unsigned char *client_digest,
-                                        const unsigned char *salt, size_t salt_size);
+                                        size_t digest_size, const unsigned char *salt, size_t salt_size);
 void hash_validator_destroy(hash_validator_t *v);
 
 int hash_crypto_func(const unsigned char *curr_seed, void *args);


### PR DESCRIPTION
This also means that indefinite sizes are now allowed for KangarooTwelve. Now instead any XOF defaults to 32 bytes when using `--random` or `--benchmark`.